### PR TITLE
fix: fixed starthip not found error on launch.

### DIFF
--- a/dot_bash_profile
+++ b/dot_bash_profile
@@ -1,0 +1,3 @@
+if [ -f "$HOME/.bashrc" ]; then
+    source "$HOME/.bashrc"
+fi

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -2,7 +2,10 @@ export EDITOR='nvim'
 export BAT_THEME="gruvbox-dark"
 export FZF_DEFAULT_COMMAND='rg --files'
 export FZF_DEFAULT_OPTS='--preview "bat --style=numbers --color=always {}"'
-eval "$(starship init bash)"
+
 export PATH="$PATH:$HOME/.local/bin"
 export PATH="$PATH:/opt/mssql-tools18/bin"
+
+source "$HOME/.nix-profile/etc/profile.d/nix.sh"
+eval "$(starship init bash)"
 


### PR DESCRIPTION
The .bashrc file wasn't being sourced when WSL was initilised, adding a .bash_profile which sources .bashrc fixed this.
Also nix wasn't being initilised until after starship was, but starship is intalled with nix. Updating .bashrc to initilise nix first fixed this.